### PR TITLE
Task.5-4 application.rbの設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,19 @@ module WonderfulEditor
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.generators do |g|
+      g.template_engine false
+      g.javascripts false
+      g.stylesheets false
+      g.helper false
+      g.test_framework :rspec,
+                       view_specs: false,
+                       routing_specs: false,
+                       helper_specs: false,
+                       controller_specs: false,
+                       request_specs: true
+    end
+    config.api_only = true
   end
 end


### PR DESCRIPTION
## 概要
### `rails generation` コマンドの修正...左記コマンドを実行していく時、余計なファイルを作らない様に設定
 - config/application.rbにテキスト分をコピペ※end 前でいい。