### PR TITLE
Task.7-1 記事に関するAPIのルーティングの実装

### DIFF
--- a/app/controllers/api/v1/article_controller.rb
+++ b/app/controllers/api/v1/article_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::ArticleController < ApplicationController
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for "User", at: "auth"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+  namespace :v1 do
+    resource :articles
+  end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Rails.application.routes.draw do
   mount_devise_token_auth_for "User", at: "auth"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   namespace :api do
-  namespace :v1 do
-    resource :articles
-  end
+    namespace :v1 do
+      resource :articles
+    end
   end
 end

--- a/spec/requests/api/v1/article_spec.rb
+++ b/spec/requests/api/v1/article_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/v1/article_spec.rb
+++ b/spec/requests/api/v1/article_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /index" do


### PR DESCRIPTION
# 概要
## はじめにAPIのendpoint(どんなURLアクセスにするか)を考え設定していく。
### APIのendpoint は　/api/v1から始まる様にする。→こうする事でAPI用のendpointである事が明確になりAPIのバージョンが明確になる。
### 一通り確認出来たら、/api/v1/articlesでCRUD処理ができる様なendpointが生える様`routes.rb`を修正
 - `$ bundle exec rails g contoroller api/v1/articles`
 - `app/contoroller/api/v1/article_contoroller.rb` `spec/request/api/v1/article_spec.rb`ができている事を確認
 - Railsドキュメントの「namespace」の記述を参考にして`routes.rb`を修正
      - namespace :api do でも 'api' do でも両方OK。スマートにする事とドキュメントを優先すると前者で記述
      - :api :v1 はモジュール名になる。ちゃんと文字列で設定させる事
      - ルート定義はresource :articles 　※'s'を忘れない様に
 - `$bundle exec rails routes`でprefix,Verb,URI pattern ができている事を確認
 　バージョンで名前を管理しておく事でバージョン管理がわかりやすくなる事でメソッドにnamespaceを使用する
　 resourceは何を動かすのか＝記事のコントローラー名に指定

## 必要な事
参考サイトを見ながら実装してみたけど、これで正しく動くか自信がない。
→ルーティングはroutes.rbで確認できるからこれであっているか確認してみる。
この動きが大事！！