### PR TITLE
Task.7-2 base_api_controllerの実装【Articleに関するAPI実装】

### DIFF
--- a/app/controllers/api/v1/article_controller.rb
+++ b/app/controllers/api/v1/article_controller.rb
@@ -1,2 +1,0 @@
-class Api::V1::ArticleController < ApplicationController
-end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::BaseApiController < ApplicationController
+end

--- a/spec/requests/api/v1/base_api_spec.rb
+++ b/spec/requests/api/v1/base_api_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::BaseApis", type: :request do
   describe "GET /index" do

--- a/spec/requests/api/v1/base_api_spec.rb
+++ b/spec/requests/api/v1/base_api_spec.rb
@@ -1,6 +1,6 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "Api::V1::Articles", type: :request do
+RSpec.describe "Api::V1::BaseApis", type: :request do
   describe "GET /index" do
     pending "add some examples (or delete) #{__FILE__}"
   end


### PR DESCRIPTION
# 概要
## applicationControllerを継承したapi_controllerを作成
  - 前回作ったファイルを一旦削除`$bundle exec rails d controller api/v1/article`
    →remove `app/controllers/api/v1/article_controller.rb` `spec/requests/api/v1/article_spec.rb` ※削除される
  - 新たに`$ bundle exec rails g controller api/v1/base_api`を作成
    ※ app/controller 配下にディレクトリを作成してbase_api_controllerを作成する
   →create `app/controllers/api/v1/base_api_controller.rb` `spec/requests/api/v1/base_api_spec.rb` ※作成される
  - ちゃんとApplicationControllerから継承されているか確認する
     
