### PR TITLE
Task.7-3 記事一覧の実装【Articleに関するAPI実装】

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,10 @@
+module Api::V1
+  # base_api_controllerを継承
+  class ArticlesController < BaseApiController
+    def index
+      articles = Article.order(updated_at: :desc)
+
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,5 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
-      resource :articles
+      resources :articles
     end
   end
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -47,7 +47,9 @@ RSpec/InstanceVariable:
 # パフォーマンスの問題さえ無ければ 1 example 1 assertion にしておく方が
 # 読みやすいテストになりやすいので、そこはレビューで担保していく必要がある。
 RSpec/MultipleExpectations:
+  Max: 10
   AggregateFailuresByDefault: true
+  Max: 10
 
 # 変に名前つけて呼ぶ方が分かりづらい。
 # テスト対象メソッドを呼ぶだけの subject 以外を書かないようにする方が効く。

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -21,6 +21,6 @@ FactoryBot.define do
   factory :article do
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
-    user { nil }
+    user
   end
 end

--- a/spec/requests/api/v1/article_spec.rb
+++ b/spec/requests/api/v1/article_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /articles" do
+    subject { get(api_v1_articles_path) }
+
+    let!(:article1) { create(:article, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, updated_at: 5.days.ago) }
+    let!(:article3) { create(:article) }
+
+    it "記事の一覧が取得出来る" do
+      subject
+      # binding.pry
+      res = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:ok)
+      expect(res.length).to eq 3
+      expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+    end
+  end
+end
+
+# RSpec.describe "Api::V1::Articles", type: :request do
+#   describe "GET /articles" do
+#     subject { get(api_v1_articles_path) }
+#     # pending "add some examples (or delete) #{__FILE__}"
+#     # 作成時間が異なる article を3つ作る
+
+#     let!(:article1) { create(:article, user_id: user.id) }
+#     let!(:article2) { create(:article, user_id: user.id) }
+#     let!(:article3) { create(:article, user_id: user.id) }
+#     let(:user) { create(:user)}
+
+#     fit "記事の一覧が取得できる" do
+#       # get api_v1_articles_path
+#       subject
+#       binding.pry
+#        # 作成した article のデータが全て返ってきているか（ article の作成時間をずらしたものを3つ作ってそれが3つとも返ってくるか）
+#        res = JSON.parse(response.body)
+#        expect(res.length).to eq 3
+#        expect(res[0].keys).to eq ["id","title","updated_at","user"]
+
+#       # article = FactoryBot.buld(:article)
+#       # article = Article.new(title: "test", body: "test_body", user_id: 1)
+#       # ステータスコードが 200 であること
+#       expect(response).to have_http_status(200)
+#     end
+#   end
+
+# end

--- a/spec/requests/api/v1/base_api_spec.rb
+++ b/spec/requests/api/v1/base_api_spec.rb
@@ -1,7 +1,7 @@
-require "rails_helper"
+# require "rails_helper"
 
-RSpec.describe "Api::V1::BaseApis", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end
+# RSpec.describe "Api::V1::BaseApis", type: :request do
+#   describe "GET /index" do
+#     pending "add some examples (or delete) #{__FILE__}"
+#   end
+# end


### PR DESCRIPTION
# 概要
## 開発(development: index)環境の実装
 - active_model_serializersを使って、記事の一覧をjsonで返す機能を実装。
    その際、serializerは記事の一覧とその他の処理のAPIに関してはレスポンスの内容を分けたいので
   /app/serializers/api/v1/article_preview_serializer.rbに記事一覧のserialiersを作成して実装。
 - active_model_serializerはviewの代わりみたいなものとして考える。 
　- `$ bundle exec rails g serializer/api/v1/article_preview` → <create> app/serializers/api/v1/article/preview_serializer.rb
　　今回は記事の一覧を表示するのでarticle_preview_serializerを作る
　- `$ bundle exec rails g api/v1/user` → <create> app/serializers/api/v1/user_serializer.rb
　   記事の一覧という事はその記事を書いたuserの情報と紐づいている必要がある為、user_seializer.rbもつくる
   -  次にbase_api_contorollerを継承したarticles_controllerを作る。
   　module Api::v1   `class ArticlesController < BaseApiController`　これを手書きで記入
　   ※`api/v1`のエンドポイントを作る理由：今後、V2,V3と実装する事が予想される為、V1空間のbase/api/controllerを継承したarticle_contorollerを作る
   -  最後にarticles_controllerを継承したarticle_controllerを作る

## テスト（test)環境
### テストで確認すべき事（index)
 - 作成したデータの全てが返ってきている事
   `$ bundle exec rspec --tag focus` > suject → 200 　※ subjectの直下でbinding.pry発動
   `$ >response.body` → データが全て返される。>response.class → String  >res = JSON.parse(response.body) → Json形式
   `$ res.length` → 3        
 - 返ってきたデータは要求したカラムのデータを持つ事
　 `$ res[0].keys`  → カラム情報　    
 - ステータスコードが200である事
　> suject → 200 　※ subjectの直下でbinding.pry発動
 
binding.pryの情報をテストに入力　