### PR TITLE
Task.7-4  記事詳細の実装【Articleに関するAPI実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,8 +3,13 @@ module Api::V1
   class ArticlesController < BaseApiController
     def index
       articles = Article.order(updated_at: :desc)
-
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+    def show
+      # binding.pry
+      article = Article.find(params[:id])
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
   end
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,0 +1,5 @@
+class Api::V1::ArticleSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body, :updated_at
+
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -22,7 +22,7 @@ RSpec/EmptyLineAfterFinalLet:
 # feature spec は exclude でも良いかもしれない。
 # ヒアドキュメント使うと一瞬で超えるので disable も検討。
 RSpec/ExampleLength:
-  Max: 8
+  Max: 15
 
 # block の方がテスト対象が
 # * `{}` の前後のスペースと相まって目立つ

--- a/spec/requests/api/v1/article_spec.rb
+++ b/spec/requests/api/v1/article_spec.rb
@@ -20,6 +20,38 @@ RSpec.describe "Api::V1::Articles", type: :request do
       expect(res[0]["user"].keys).to eq ["id", "name", "email"]
     end
   end
+
+  describe "GET /articles/:id" do
+    subject { get(api_v1_article_path(article_id)) }
+
+    context "指定したidの記事が存在する時" do
+      let(:article_id) { article.id }
+      let(:article) { create(:article) }
+
+      it "その詳細が取得出来る" do
+        subject
+        # binding.pry
+        res = JSON.parse(response.body)
+        expect(res["id"]).to eq article.id
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
+        expect(res["updated_at"]).to be_present
+        expect(res["user"]["id"]).to eq article.user.id
+        expect(res["user"].keys).to eq ["id", "name", "email"]
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "指定したidの記事が存在しない時" do
+      let(:article_id) { 10000 }
+
+      it "記事が見つからない" do
+        # binding.pry
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
 end
 
 # RSpec.describe "Api::V1::Articles", type: :request do


### PR DESCRIPTION
# 概要
## Requset Spec【Showメソッド】　※参考 「Request　Specを書こう（show編）」
### やった事
 - spec/request/api/v1/article_spec.rb
    showメソッドの正常系の実装　※①指定したidのテーブルのデータが返ってくる事②ステータスコードが200である事
　showメソッドの異常系の実装　※①存在しないユーザーのidを指定してレコードが見つからない事
 - app/controllers/api/v1/article_controller.rb
 　`def show ~end`の実装：`article = Article.find(params[:id] )``render json : article, serializer::Api::V1::ArticleSerializer `
　  ※routes.rbから飛んだリクエストをモデル（Spec）を経由してserializerで指定の表示を設定させてJSONで返す様に指示。
 - app/serializers/api/v1/article_serializer.rb
    `class Api::V1::ArticleSerializer < ActiveModel::Serializer``attributes: id, :title, :body, :updated_at`
    `belongs_to : user, serializer :Api::V1::UserSerializer` ※ここにはクライアントに指定された記事の情報を全て返す。
### テスト方法
 正常系
 - `$ bundle exec rspec --tag focus` ※`f`を指定する
 - `> subject` →200
 - `>response.body`→　データ  `>response.body.class`→String
 - `>res = JSON.parse(response.body)`→ JSONデータ
 - `>article["title"]` →　XXX　←　`>res ["title"]`  ※テーブルとレスポンスが同じ情報である事を確認する。
異常系
 - `>subject`→ エラー情報を`expect{ subject } .to raise_error (エラー情報）をSpecに記入`