### PR TITLE
Task.7-5 記事作成の実装【Articleに関するAPI実装】

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,15 +1,30 @@
 module Api::V1
   # base_api_controllerを継承
   class ArticlesController < BaseApiController
+    # before_action :authenticate_user!, only: [:create]
+
     def index
       articles = Article.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      # binding.pry
       article = Article.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
+
+    def create
+      # インスタンスをmodelから作成する
+      # インスタンスをDBに保存する falseでなくerrorで返せる様に'！'をつける
+      article = current_user.articles.create!(article_params)
+      # jsonとして返す
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
+    private
+
+      def article_params
+        params.require(:article).permit(:title, :body)
+      end
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
+  def current_user
+    @current_user ||= User.first
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
   # skip_before_action :verify_authenticity_token, if: :devise_controller? # APIではCSRFチェックをしない
+  protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,17 +33,19 @@ module WonderfulEditor
     config.generators.system_tests = nil
 
     config.generators do |g|
-      g.template_engine false
-      g.javascripts false
-      g.stylesheets false
-      g.helper false
-      g.test_framework :rspec,
-                       view_specs: false,
-                       routing_specs: false,
-                       helper_specs: false,
-                       controller_specs: false,
-                       request_specs: true
+      g.template_engine false #  HTML を作成しない
+      g.javascripts false # javascripts ファイルを作成しない
+      g.stylesheets false # スタイルシート(CSS)を作成しない
+      g.helper false # helper を作成しない
+      g.test_framework :rspec, # テストファイルを作成する
+                       view_specs: false, # view の spec を作成しない
+                       routing_specs: false, # routing の spec を作成しない
+                       helper_specs: false, # helper の spec を作成しない
+                       controller_specs: false, # contoller の spec を作成しない
+                       fixtures: true, # factory_bot のファイルを作成する
+                       request_specs: true # request の spec を作成する
     end
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash # CSRF 対策を OFF にする
   end
 end

--- a/spec/requests/api/v1/article_spec.rb
+++ b/spec/requests/api/v1/article_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     it "記事の一覧が取得出来る" do
       subject
-      # binding.pry
+
       res = JSON.parse(response.body)
 
       expect(response).to have_http_status(:ok)
@@ -30,7 +30,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
       it "その詳細が取得出来る" do
         subject
-        # binding.pry
+
         res = JSON.parse(response.body)
         expect(res["id"]).to eq article.id
         expect(res["title"]).to eq article.title
@@ -47,8 +47,37 @@ RSpec.describe "Api::V1::Articles", type: :request do
       let(:article_id) { 10000 }
 
       it "記事が見つからない" do
-        # binding.pry
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+
+  describe "POST /articles" do
+    subject { post(api_v1_articles_path, params: params) }
+
+    context "適切なパラメーターを送信した時" do
+      let(:params) { { article: attributes_for(:article) } }
+      let(:current_user) { create(:user) }
+      # FactoyBotでuserを作成: 変数を currnt_user_stub
+
+      # stub
+      # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+      # allow_any_instance_of(A:クラス名).to receive(B:メソッド名).and_return(C:戻り値)とするとAのインスタンスで、Bを呼び出した場合、Cを返す
+
+      it "ユーザーの記事を作成出来る" do
+        expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "不適切なパラメーターを送信した時" do
+      let(:params) { attributes_for(:article) }
+
+      it "エラーする" do
+        expect { subject }.to raise_error(NoMethodError)
       end
     end
   end


### PR DESCRIPTION
# 概要
## 環境設定
 - base_api_controllerの中に`def current_user`メソッドを作る。
 - ルーティングはコントローラーが継承されてるのでresources : articlesでOK
 - articles_controller.rbには`def create ~end`とストロングパラメーターを作成
 - binding.pryを入れてpostman(HTTPクライアント）でチェック。>current_user→nilを確認
 - base_api_controller.rb `def current_userに@current ||= User.first / endを実装→「current_userメソッド」に関するブログ記事で記述を確認
 - 次に>params→nilで返ってきたのでpostmanでarticleの新規情報を入力（TablePlusにレコードが入っている事を確認）
 - ストロングパラメーターの確認>params→pertted false、>article_params→permited true 確認
 
## テスト環境
 - article_spec.rb にPOSTのコードを記述。RspecはShowメソッドの方法に合わせれば大きな違いはない。