### PR TITLE
Task.7-7 記事削除の実装【Articleに関するAPI実装】

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -30,6 +30,15 @@ module Api::V1
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
+    def destroy
+      # 対象のレコードを探す
+      article = current_user.articles.find(params[:id])
+      # 探してきたレコードを削除する
+      article.destroy!
+      # jsonとして値を返す
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
     private
 
       def article_params


### PR DESCRIPTION
# 概要
## 開発環境
 - app/controllers/api/v1/articles_controller.rb に`def destroy ~`を記入
 - `article = current_user.articles.find(params[:id])` updateメソッドと同じ記述
 - `article.destroy` ActiveRecordで実装
 
## テスト環境
### 正常系
 - describeとsubjectの定義は同じ
 - `let( :current_user ){ create(:user) }` letでcurrent_userを定義する
 - `before { allow_any_instans_of`~ } を定義する　※ 異常系定義で　rubocopエラーするので確認が必要
 - contextの所で`let!(article){ create(:article, user: current_user) }`articleにはcreateしたarticleとその（current_userで代入した）ユーザーを定義する
 - itでsubjectを呼び出し、見つかればその記事を（ー1）削除する
 - その際、subjectのレスポンスは（200：ok）で返す
 
### 異常系
- `let( :other_user ){ create(:user) }` letで登録されていない別のユーザー（今回はother_user)を定義する
 - contextの所で`let!(article){ create(:article, user: other_user) }`articleにはcreateしたarticleとその（other_userで代入した）ユーザーを定義する
 - itでsubjectを呼び出し、見つからなければその記事は削除できないエラー(今回はActiveRecord::RecordNotFound)を提示して削除できない戻り値を出す。