### PR TITLE
Task.9-1 新規登録APIの実装【新規登録・ログイン・ログアウト機能の実装】

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  private
+
+    def sign_up_params
+      params.permit(:name, :email, :password, :password_confimation)
+    end
+
+    def account_update_params
+      params.permit(:name, :email)
+    end
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+  config.headers_names = { 'access-token': "access-token",
+                           client: "client",
+                           expiry: "expiry",
+                           uid: "uid",
+                           'token-type': "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: "api/v1/auth/registrations",
+      }
       resources :articles
     end
   end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
# 概要
## 今回の実装
 - devise_token_authを使ってユーザーの新規登録を行うAPIの実装
 - 条件：APIのendpointはPOST/api/v1/auth
 - この新規登録のAPIを呼び出して**ユーザー登録**をした後に返ってくるレスポンスのヘッダーの情報に**「トークン情報」**が含まれる。なのでPostmanで上記endpointのAPIを呼び出し、reponseの中に含まれるheader情報にdevise_token_authが提供するトークン情報が確認されたらOK
 - ※ユーザー情報：メールアドレス、パスワード
 - ※トークン：新規登録・ログインした際に、そのユーザーの情報（トークン情報）を識別する為のワンタイムパスワード
 - ※**トークン情報：access-token / client / uid が存在している事** 
 - まとめると、ユーザーが新規登録をしたり、ログインするとdevise_token_authがトークンを載せてユーザー認証に必要な情報を返す。新規登録をする際に必要な情報であるemailとpasswordを入力し、リクエストが成功するとトークン情報（ヘッダー情報とトークン）が返ってくる。
 - ユーザー認証
    1. sessionとcookieによるもの
    2. トークン認証　「decvise_token_auth」を使うとトークン認証を使ったユーザー認証機能が実装出来る。
    3. JWT認証　←広い意味ではトークン認証のうちのひとつだが、その中でも少し特殊
   
## 実装方法
 1. devise_token_authを用いた認証を行うコントローラーをコマンドで作成`$ bundle exec rails g  controller api/v1/auth/registration` 入力
 2. [app/controllers/api/v1/auth/registrations_controller.rb]が出来ている事とクラスが`class V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController end`と継承されている事を確認。（specディレクトリのファイルもできている）これは何をしているのか？→devise_token_authのgemであらかじめ用意されている認証用のコントローラーを作成したregistrations_contorollerに継承している。
 3. 継承されたコントローラーにメソッドを記入。[private/def sign_up_params / params.permit(:name, :email. :password,:password_confirmation) end]と更新用のメソッドもオーバーライドしておく[def account_update_params/ params.permit(:name, :email) end]
 4. 継承したコントローラーを使用し、次のルーティング設定する事で使用するアプリの認証機能を実現する事が可能になる。
 　namespace :api do / namespace :v1 do / mount_devise_token_auth_for "User", at: "auth", controllers: { registrations: "api/v1/auth/registrations" } 省略　**※エラーで[ROLL BACK]と返ってきたらルーティングがコントローラーに渡っていない可能性あり**
 5. 認証時、レスポンスとして返すHeader情報を設定する [config/initializers/devise_token_auth.rb]ヘッダー情報の毎回のリクエストはfalse、期限は2週間、ヘッダーnameの構成とか
 6. 継承元の[RegistrationsController]はどこに存在するか？→vender/bundle配下にあるがコード上では非設定になっている。
 
### 参考リンク
https://qiita.com/tomokazu0112/items/5fdd6a51a84c520c45b5#%E6%96%B0%E8%A6%8F%E7%99%BB%E9%8C%B2
 