### PR TITLE
Task.9-2 新規登録APIのテストの実装【新規登録・ロウイン・ログアウト機能の実装】

### DIFF
--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,7 +1,81 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe "POST /v1/auth" do
+    subject { post(api_v1_user_registration_path, params: params) }
+
+    context "適切なパラメーターを送信した時" do
+      let(:params) { attributes_for(:user) }
+
+      it "ユーザーレコードが1つ作成される" do
+        expect { subject }.to change { User.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["data"]["name"]).to eq params[:name]
+        expect(res["data"]["email"]).to eq params[:email]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "password_confimationの値がpasswordと異なるとき" do
+      let(:params) { attributes_for(:user, password_confimation: "") }
+
+      it "エラーする" do
+        expect { subject }.to raise_error(NameError)
+      end
+    end
+
+    context "メールアドレス、パスワードが正しいとき" do
+      let(:params) { attributes_for(:user) }
+
+      it "ログインできる" do
+        subject
+        header = response.header
+        expect(header["uid"]).to be_present
+        expect(header["access-token"]).to be_present
+        expect(header["client"]).to be_present
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "nameが正しくない時" do
+      let(:params) { attributes_for(:user, name: "") }
+
+      it "ログインできない" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["data"]["name"]).to eq params[:name]
+        expect(res["errors"]["name"]).to include "can't be blank"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "emailが正しくない時" do
+      let(:params) { attributes_for(:user, email: "") }
+
+      it "ログインできない" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["data"]["email"]).to eq params[:email]
+        expect(res["errors"]["email"]).to include "can't be blank"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
+
+  # describe "DELETE / registrations" do
+  #   subject { delete(api_v1_user_registration_path, headers: headers) }
+  #   context "ユーザーがログインしている時" do
+  #     let(:user){ create(:user) }
+  #     let(:headers) { user.create_new_auth_token}
+
+  #     fit "ログアウト出来る" do
+  #       binding.pry
+  #       subject
+  #       res = JSON.parse(response.body)
+  #         expect(res["status"]["success"]).to be_truthy
+  #         expect(user.reload.tokens).to be_blank
+  #         expect(response).to have_http_status(:ok)
+  #     end
+  #   end
+  # end
 end


### PR DESCRIPTION
# 概要
## 手順
 - request_specのファイル`spec/requests/api/v1/auth/registrations_spec.rb`を作成する
 - 正常系のパターンを洗い出す
   - 適切なパラメータを送信した時にユーザーレコードが1つ作成される事
   - ユーザーレコードが正しい時にログインできる事（ヘッダーで表示されるトークン情報が返ってくる事） 
 - 異常系のパターンを洗い出す
   - 適切なパラメータが送信されない時にユーザーレコードが作成されない事
   - ユーザーレコードが正しくない時にログイン出来ない事（エラーで返ってくる事） 
   
### ポイント
特に今回のテストでは「ユーザーの新規登録ができた時にヘッダー情報が取得できる事」がポイント。今まではレスポンスのbodyを取得して確認出来たと思うが、`response.header`と入力する事でヘッダー情報が確認できる。この様に取得できる事はもちろん知らないと思うのでこういった時に以下の様に記述して処理を止める。
```
it "header 情報を取得することができる" do
  subject
  # ここでヘッダー情報を取得したい
  binding.pry
  header = response
end
```
ここで処理を止めて`ls response`をしてヘッダー情報を取得するメソッドを確認したり、「rspec response header　取得」などのキーワードでググるのもひとつ。