### PR TITLE
Task.9-4 ログアウトAPIの実装【新規登録・ログイン・ログアウト機能の実装】

### DIFF
--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -51,22 +51,34 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
     end
   end
 
-  # describe "DELETE /api/v1/auth/sign_out" do
-  #   subject { delete(destroy_api_v1_user_session_path, params: params, headers: headers) }
+  describe "DELETE /api/v1/auth/sign_out" do
+    subject { delete(destroy_api_v1_user_session_path, params: params, headers: headers) }
 
-  #   context "ユーザーがログインからログアウトする時" do
-  #     let(:user) { create(:user) }
-  #     let(:params) { attributes_for(:user) }
-  #     let!(:headers) { user.create_new_auth_token }
+    context "ユーザーがログインからログアウトする時" do
+      let(:user) { create(:user) }
+      let(:params) { attributes_for(:user) }
+      let!(:headers) { user.create_new_auth_token }
 
-  #     fit "トークンを無くしログアウト出来る" do
-  #       expect { subject }.to change { user.reload.tokens }.from(be_present).to(be_empty)
+      it "トークンを無くしログアウト出来る" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["success"]).to be_truthy
+        expect(user.reload.tokens).to be_blank
+        expect(response).to have_http_status(:ok)
+      end
+    end
 
-  #       res = JSON.parse(response.body)
-  #         expect(res["success"]).to be_truthy
-  #         expect(user.reload.tokens).to be_blank
-  #         expect(response).to have_http_status(:ok)
-  #     end
-  #   end
-  # end
+    context "ユーザーが誤った情報でログアウトする時" do
+      let(:user) { create(:user) }
+      let(:params) { attributes_for(:user) }
+      let!(:headers) { { "access-token" => "", "client" => "", "uid" => "" } }
+
+      it "ログアウト出来ない" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["errors"]).to include "User was not found or was not logged in."
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# 概要
### devise_token_suthを使用したログアウトに関する実装
 - ルーティングの`destroy_api_v1_user_session DELETE /api/v1/auth/sign_out`を引用
 - 新規作成時、ログイン時にトークン情報が発行され、その情報を元にログアウトの処理を行うが現状のコードではuser情報は作成されてもトークン情報は作成されない。
 - トークン情報を入れるには？：`create_new_auth_token`メソッドを使う→必要なメタデータ全てを含む認証トークンを作成してくれる。
 - `expect(user.reload.tokens).to be_blank`をit句で使う事によりuserの値を更新して有効なトークン情報をなくす事が出来る。
 - 異常系は誤った情報でログアウトする際、ログアウトできない様に実装する。
 
参考記事
https://qiita.com/1078sa08002/items/c15224f796525320cc80