### PR TITLE
Task.9-5 既存APIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,7 +1,7 @@
 module Api::V1
   # base_api_controllerを継承
   class ArticlesController < BaseApiController
-    # before_action :authenticate_user!, only: [:create]
+    before_action :authenticate_user!, only: [:create, :update, :destroy]
 
     def index
       articles = Article.order(updated_at: :desc)

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-  def current_user
-    @current_user ||= User.first
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end


### PR DESCRIPTION
# 概要
## ダミーメソッドの削除と`devise_token_auth`ヘルパーメソッドの追加とエイリアスの実装
### base_api_controllerにダミーメソッドとして使っている`current_user`の対応
 - api_contorollerのダミーコードであるcurrent_userメソッドを削除
 - base_api_controllerでdevise_token_authで提供されている各種メソッドを使える様にする
   - current_user     ログインしているユーザー
   - authenticate_user!　ログイン済みユーザーのみアクセスを許可する
   - user_signed_in?  　ユーザーがサイン済みかどうか判定する
 - ログインしていないと使えないAPIはauthenticate_user!で弾く様に実装
 - テストでログインが必要なAPIを叩く際にheader情報を渡す様に実装
 
## 実装のポイント
### トークンの各種ヘルパーメソッドの意味
 - 上記devise_token_authのヘルパーメソッドを記述する時はroutes.rbの内容次第で変更しなければならない。
 - ルーティングで`namespace`が使われているので/api/v1/authの様になる。
   - current_user　→  current_api_v1_user
   - authenticate_user! → authenticate_api_v1_user!
   - user_signed_in?  →  api_v1_user_sirned_in?
 - エイリアスメソッドの記述　`alias_method :新メソッド :旧メソッド` → `alias_method :current_user`:current_api_v1_user
 - 残りの2項目も同じ様に記述する。
 - エイリアス：偽名、別名、通称などの意味を持つ英単語。長文を省略したい時やシンボルをつくるイメージ