### PR TITLE
Task.11-2 既存のAPIの修正【下書き機能の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -4,7 +4,8 @@ module Api::V1
     before_action :authenticate_user!, only: [:create, :update, :destroy]
 
     def index
-      articles = Article.order(updated_at: :desc)
+      # articles = Article.order(updated_at: :desc)
+      articles = Article.published.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
@@ -18,7 +19,7 @@ module Api::V1
       # インスタンスをDBに保存する falseでなくerrorで返せる様に'！'をつける
       article = current_user.articles.create!(article_params)
       # jsonとして返す
-      render json: article, serializer: Api::V1::ArticleSerializer
+      render json: article
     end
 
     def update
@@ -27,7 +28,7 @@ module Api::V1
       # 探してきたレコードに対して変更を行う
       article.update!(article_params)
       # jsonとして値を返す
-      render json: article, serializer: Api::V1::ArticleSerializer
+      render json: article
     end
 
     def destroy
@@ -42,7 +43,7 @@ module Api::V1
     private
 
       def article_params
-        params.require(:article).permit(:title, :body)
+        params.require(:article).permit(:title, :body, :status)
       end
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -19,8 +19,8 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Article < ApplicationRecord
-  validates :title, presence: true
-  validates :body, presence: true
+  # validates :title, presence: true
+  # validates :body, presence: true
   # validates :user_id, presence: true
 
   belongs_to :user

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at, :status
 
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,12 +18,10 @@ ActiveRecord::Schema.define(version: 2021_08_17_214706) do
   create_table "article_likes", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "user_id"
-    # t.bigint "{:foreign_key=>true}_id"
+    t.bigint "user_id", null: false
     t.bigint "article_id", null: false
     t.index ["article_id"], name: "index_article_likes_on_article_id"
     t.index ["user_id"], name: "index_article_likes_on_user_id"
-    # t.index ["{:foreign_key=>true}_id"], name: "index_article_likes_on_{:foreign_key=>true}_id"
   end
 
   create_table "articles", force: :cascade do |t|

--- a/spec/requests/api/v1/article_spec.rb
+++ b/spec/requests/api/v1/article_spec.rb
@@ -4,13 +4,14 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /articles" do
     subject { get(api_v1_articles_path) }
 
-    let!(:article1) { create(:article, updated_at: 1.days.ago) }
-    let!(:article2) { create(:article, updated_at: 5.days.ago) }
-    let!(:article3) { create(:article) }
+    let!(:article1) { create(:article, :published, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, :published, updated_at: 5.days.ago) }
+    let!(:article3) { create(:article, :published) }
 
-    it "記事の一覧が取得出来る" do
+    before { create(:article, :draft) }
+
+    it "公開済み記事の一覧が取得出来る（更新順）" do
       subject
-
       res = JSON.parse(response.body)
 
       expect(response).to have_http_status(:ok)
@@ -28,25 +29,28 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     context "指定したidの記事が存在する時" do
       let(:article_id) { article.id }
-      let(:article) { create(:article) }
+      context "対象の記事が公開中である時" do
+        let(:article) { create(:article, :published) }
 
-      it "その詳細が取得出来る" do
-        subject
+        it "その記事が取得出来る" do
+          subject
 
-        res = JSON.parse(response.body)
-        expect(res["id"]).to eq article.id
-        expect(res["title"]).to eq article.title
-        expect(res["body"]).to eq article.body
-        expect(res["updated_at"]).to be_present
-        expect(res["user"]["id"]).to eq article.user.id
-        expect(res["user"].keys).to eq ["id", "name", "email"]
+          res = JSON.parse(response.body)
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["updated_at"]).to be_present
+          expect(res["user"]["id"]).to eq article.user.id
+          expect(res["user"].keys).to eq ["id", "name", "email"]
 
-        expect(response).to have_http_status(:ok)
+          expect(response).to have_http_status(:ok)
+        end
       end
     end
 
-    context "指定したidの記事が存在しない時" do
-      let(:article_id) { 10000 }
+    context "対象の記事が下書きである時" do
+      let(:article) { create(:article, :draft) }
+      let(:article_id) { 100000 }
 
       it "記事が見つからない" do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
@@ -57,8 +61,8 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "POST /articles" do
     subject { post(api_v1_articles_path, params: params, headers: headers) }
 
-    context "適切なパラメーターを送信した時" do
-      let(:params) { { article: attributes_for(:article) } }
+    context "公開設定で記事を作成した時" do
+      let(:params) { { article: attributes_for(:article, status: "published") } }
       let(:current_user) { create(:user) }
       # FactoyBotでuserを作成: 変数を currnt_user_stub
 
@@ -67,18 +71,35 @@ RSpec.describe "Api::V1::Articles", type: :request do
       # allow_any_instance_of(A:クラス名).to receive(B:メソッド名).and_return(C:戻り値)とするとAのインスタンスで、Bを呼び出した場合、Cを返す
       let(:headers) { current_user.create_new_auth_token }
 
-      it "ユーザーの記事を作成出来る" do
+      it "公開設定の記事を作成出来る" do
         expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
         res = JSON.parse(response.body)
         expect(res["title"]).to eq params[:article][:title]
         expect(res["body"]).to eq params[:article][:body]
+        expect(res["status"]).to eq params[:article][:status]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "下書き設定で記事を作成した時" do
+      let(:params) { { article: attributes_for(:article, status: "draft") } }
+      let(:current_user) { create(:user) }
+
+      let(:headers) { current_user.create_new_auth_token }
+
+      it "下書き設定の記事を作成できる" do
+        expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(res["status"]).to eq params[:article][:status]
         expect(response).to have_http_status(:ok)
       end
     end
 
     context "不適切な status のパラメータを送信したとき" do
       let(:current_user) { create(:user) }
-      let(:params) { attributes_for(:article) }
+      let(:params) { attributes_for(:article, status: "foo") }
       let(:headers) { current_user.create_new_auth_token }
 
       it "エラーになる" do
@@ -90,13 +111,13 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "PATCH(PUT)/articles/:id" do
     subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
-    let(:params) { { article: attributes_for(:article) } }
+    let(:params) { { article: attributes_for(:article, :published) } }
     let(:current_user) { create(:user) }
 
     let(:headers) { current_user.create_new_auth_token }
 
     context "任意の記事のレコードを更新しようとするとき" do
-      let(:article) { create(:article, user: current_user) }
+      let(:article) { create(:article, :draft, user: current_user) }
 
       it "任意の記事のレコードを更新出来る" do
         expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &


### PR DESCRIPTION
# 概要
## タスク内容
 - 公開されている記事だけ取得できる様にする。
 - 記事を作成する場合は、記事の公開/非公開を選択できる様にする。
 
## 補足
 今の記事の一覧、記事詳細のAPIは下書き状態のものも含めて取得できる様になっている。
 また、記事の作成や更新では、公開/下書きの状態を指定していない。
 前述の条件を満たす様にコントローラーの修正を行う。

### ポイント
 - 既存のserializerファイルにstatusの値を追加
 - rails c でデーターを追加
 - controllerにenumで設定しているメソッドを使い`articles = Article.published.order(updated_at: :desc)`を記述する。
 - strong parameterのpermitの引数にもstatusを追加→article_paramsが引数になっているので受け取れる様にする。
 - テストではsubjectで期待通りのエラーが出てくる事に着眼点を置いて記述する