### PR TITLE
Task.11-3 下書き記事の一覧/詳細のAPI実装【下書き機能の実装】

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,15 @@
+module Api::V1
+  class Articles::DraftsController < BaseApiController
+    before_action :authenticate_user!
+
+    def index
+      articles = current_user.articles.draft.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+    def show
+      article = current_user.articles.draft.find(params[:id])
+      render json: article
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  describe "GET /api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    context "下書き記事が存在する時 " do
+      let!(:article1) { create(:article, :draft, user: current_user, updated_at: 1.days.ago) }
+      let!(:article2) { create(:article, :draft, user: current_user, updated_at: 5.days.ago) }
+      let!(:article3) { create(:article, :draft) }
+
+      it "下書き記事の一覧が取得できる" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 2
+        expect(res[0]["id"]).to eq article1.id
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+  end
+
+  describe "GET /api/v1/articles/drafts/:id " do
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    context "指定したidの下書き記事が存在する時" do
+      let(:article_id) { article.id }
+      let(:article) { create(:article, :draft, user: current_user) }
+
+      it "その記事を取得出来る" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["id"]).to eq article.id
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
+        expect(res["updated_at"]).to be_present
+        expect(res["user_id"]).to eq article.user_id
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "対象の記事が公開記事である時" do
+      let(:article_id) { article.id }
+      let(:article) { create(:article, :published, user: current_user) }
+
+      it "記事が見つからない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    context "対象の記事が他のユーザーの下書き記事である時" do
+      let(:article_id) { 100000 }
+      let(:article) { create(:article, :published, user: current_user) }
+
+      it "記事が見つからない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 概要
## タスク内容 
 - 自分が書いた下書きの一覧と詳細を取得するAPIとテストの実装。
 - endpointの設定
 　- index: /api/v1/articles/draft
 　- show:/api/v1/articles/draft/:id
 　実装済みの記事の一覧/詳細のAPIは「公開済み」のものしか取得できない。
　しかし、自分で書いた下書き記事は閲覧できる必要がある。
　そこで、自分が書いた下書き記事の一覧を取得するAPIとテストを実装する。

## 補足
### 読むべき記事「DHHはどの様にコントローラーを書くのか：Rails開発者
 - コントローラーはシンプルにindex,show,create,update,deleteとデフォルトのCRUD処理を使う事、追加で機能を実装したい時に新しくcontorollerを作るという考え方。

### ポイント
 - `$ bundle exec rails g controller api/v1/articles/drafts`を実行→コントローラーとスペックが自動生成される。
 - route.rbに記述するresourcesの意味：必要なアクションを指定
```
 resources :リソース名 only: [:アクション名, :アクション名]
 resources  :drafts only:[ :index, :show ]    ※controllerにあるdraftsファイルにindexとshowのメソッドのみ指定する
```
 - `before_action :authenticate_user!`意味：全てのアクションの前にユーザーがログインしているか確認する。
 - $ rails routes でpathやURIパターンを作成させるにはroutes.rbの記述(resources)で編集する！ 
 - 自動生成されたコントローラーにindexとshowメソッドを記述。api/v1/articles/で作成したメソッドを参考
 - postmanで`http://localhost:3000/api/v1/articles/drafts`→"errors": [ "You need to sign in or sign up before continuing." ]表示を確認
 - スペックについてもspec/api/v1/article_specの記述を参考にして実装する。
