### PR TITLE
Task.12 自分が書いた記事一覧の取得

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,10 @@
+module Api::V1
+  class Current::ArticlesController < BaseApiController
+    before_action :authenticate_user!
+
+    def index
+      articles = current_user.articles.published.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,11 @@ Rails.application.routes.draw do
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end
+
+      namespace :current do
+        resources :articles, only: [:index]
+      end
+
       resources :articles
     end
   end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+  describe "GET /api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path, headers: headers) }
+
+    let(:headers) { current_user.create_new_auth_token }
+    let(:current_user) { create(:user) }
+
+    context "自分の書いた公開済み記事が存在する時" do
+      let!(:article1) { create(:article, :published, user: current_user, updated_at: 1.days.ago) }
+      let!(:article2) { create(:article, :published, user: current_user, updated_at: 5.days.ago) }
+      let!(:article3) { create(:article, :published, user: current_user) }
+
+      before do
+        create(:article, :draft, user: current_user)
+        create(:article, :published)
+      end
+
+      it "自分の書いた公開済み記事の一覧が取得出来る" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 3
+        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+        expect(res[0]["user"]["id"]).to eq current_user.id
+        expect(res[0]["user"]["name"]).to eq current_user.name
+        expect(res[0]["user"]["email"]).to eq current_user.email
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 概要
## タスク内容
 - 自分が書いた公開記事の一覧を取得するAPIとテストを実装。
 - endpointを設定する。
    - /api/v1/current/articles 
 
 WonderfulEditorではマイページの閲覧を想定している。
マイページに表示するデータとして、自分が書いた公開記事の一覧取得を目的としたAPIを作成していく。

### ポイント
 - 記述方法：コマンドでコントローラー配下のファイルを自動生成（コントローラー、スペックリクエスト）
 - endpointが/api/v1/current/articles → 新たなcurrentというのはしっかり見ればわかる様にファイルではなくディレクトリ。
 - 今回の指示は「公開記事の一覧を取得する」という事はindexの取得のみでOK→複数系のディレクトリはいらない、単数系のファイルはいらない。
 - indexのみを橋渡しするルーティングをroutes.rbに追記（namespaceとresourcesの記述）
 - namespaceで渡ってきているからモジュールを揃えて継承内容を確認
 - indexメソッドを記述　※api/v1/articles/draftを参考
 - postmanでhttp://localhost:3000/api/v1/articles/drafts→"errors": [ "You need to sign in or sign up before continuing." ]表示を確認
 - スペックについてもspec/requests/api/v1/articles/draft_spec.rbの記述を参考にする。